### PR TITLE
fix: configure language as "hidden"

### DIFF
--- a/languages/comment/config.toml
+++ b/languages/comment/config.toml
@@ -1,2 +1,3 @@
 name = "comment"
 grammar = "comment"
+hidden = true


### PR DESCRIPTION
This tells Zed that this is not a "real" language: it should only be used for syntax highlighting and does not provide any language features like syntax, comment chars, etc. In my (brief) testing, it fixed the issues we saw in #3 without needing any changes to Zed. I tested this in Rust, and also in some PHP files.

`hidden` itself seems to be "hidden" in the docs, but the code explains this: https://github.com/zed-industries/zed/blob/d4b5bb9f173d78d5795387269edc68f979024898/crates/language/src/language.rs#L764-L767. It's used in "lanugages" like [jsdoc](https://github.com/zed-industries/zed/blob/main/crates/languages/src/jsdoc/config.toml#L8) and [phpdoc](https://github.com/zed-extensions/php/blob/main/languages/phpdoc/config.toml#L10)

Fixes #3