### PR TITLE
Add RBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The table below lists each language’s comment injection status: ✅ supported;
 | Make          | ⚠️                                       | https://github.com/caius/zed-make/pull/27            |
 | PHP           | ✅                                       | https://github.com/zed-extensions/php/pull/66        |
 | Python        | ✅                                       | https://github.com/zed-industries/zed/pull/39884     |
+| RBS           | ✅                                       | https://github.com/zed-industries/zed/pull/15778     |
 | Ruby          | ⚠️                                       | https://github.com/zed-extensions/ruby/pull/203      |
 | Rust          | ✅                                       | https://github.com/zed-industries/zed/pull/39714     |
 | Scala         | ✅                                       | N/A                                                  |


### PR DESCRIPTION
Follow up to #29, this adds RBS (Ruby Type Signatures). This was added quite a while ago when the whole language definition was added: https://github.com/zed-industries/zed/pull/15778.