### PR TITLE
enhance: make colon optional

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/thedadams/zed-comment"
 
 [grammars.comment]
 repository = "https://github.com/thedadams/tree-sitter-comment"
-rev = "1e65418890043cd3fcbd08d5ae49106ba1be73f1"
+rev = "7c7c0463ea14b02e3f71fb7ab074b0a08fa182b1"

--- a/languages/comment/highlights.scm
+++ b/languages/comment/highlights.scm
@@ -3,7 +3,7 @@
   ("(" @punctuation.bracket
     (user) @emphasis.comment.user
     ")" @punctuation.bracket)?
-  ":" @punctuation.delimiter
+  ":"? @punctuation.delimiter
   (text)? @constant.comment.todo.text)
   (#match? @_name "^[</#*;+\\-!| \t]*(TODO|WIP)$"))
 
@@ -12,7 +12,7 @@
   ("(" @punctuation.bracket
     (user) @emphasis.comment.user
     ")" @punctuation.bracket)?
-  ":" @punctuation.delimiter
+  ":"? @punctuation.delimiter
   (text)? @string.comment.info.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(NOTE|XXX|INFO|DOCS|PERF|TEST)$"))
 
@@ -21,7 +21,7 @@
   ("(" @punctuation.bracket
     (user) @emphasis.comment.user
     ")" @punctuation.bracket)?
-  ":" @punctuation.delimiter
+  ":"? @punctuation.delimiter
   (text)? @property.comment.error.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(FIXME|BUG|ERROR)$"))
 
@@ -30,6 +30,6 @@
   ("(" @punctuation.bracket
     (user) @emphasis.comment.user
     ")" @punctuation.bracket)?
-  ":" @punctuation.delimiter
+  ":"? @punctuation.delimiter
   (text)? @keyword.comment.warn.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(HACK|WARNING|WARN|FIX)$"))


### PR DESCRIPTION
The colon being optional means that comments like `// TODO something` will be highlighted.

Issue: https://github.com/thedadams/zed-comment/issues/23