### PR TITLE
Mark Ruby as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The table below lists each language’s comment injection status: ✅ supported;
 | PHP           | ✅                                       | https://github.com/zed-extensions/php/pull/66        |
 | Python        | ✅                                       | https://github.com/zed-industries/zed/pull/39884     |
 | RBS           | ✅                                       | https://github.com/zed-industries/zed/pull/15778     |
-| Ruby          | ⚠️                                       | https://github.com/zed-extensions/ruby/pull/203      |
+| Ruby          | ✅                                       | https://github.com/zed-extensions/ruby/pull/203      |
 | Rust          | ✅                                       | https://github.com/zed-industries/zed/pull/39714     |
 | Scala         | ✅                                       | N/A                                                  |
 | Scheme        | ✅                                       | https://github.com/zed-extensions/scheme/pull/5      |


### PR DESCRIPTION
https://github.com/zed-extensions/ruby/pull/203 was merged 🥳 