### PR TITLE
fix: theme colon and user information the same as the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ An extension for the Zed text editor to highlight according to the corresponding
 - INFO:, NOTE:, XXX:, DOCS:, PERF:, TEST: (`string`)
 - ERROR:, FIXME:, BUG: (`property`)
 - WARN:, HACK:, WARNING:, FIX: (`keyword`)
-- If the comment has a user in it (like `TODO(thedadams):`), then the user will be highlighted as `emphasis`.
-- By default, anything after the `:` is highlighted the same as the name (`TODO`, `INFO`, `ERROR`, etc). See [Theme Overrides](#theme-overrides) for customization.
+- By default, the user (in the case of something like `NOTE(thedadams):`) and anything after the name and/or user is highlighted the same as the name (`TODO`, `INFO`, `ERROR`, etc). See [Theme Overrides](#theme-overrides) for customization.
 
 Ideally, the coloring would be supported by definitions like `comment.info` and `comment.warning`, but those aren't officially supported by Zed themes. However, it is possible to customize these colors using the [Theme Overrides](#theme-overrides) below.
+
+## Breaking Changes
+
+Prior to version v0.4.0, for a comment like `HACK(thedadams)`, the parenthesis and user were styled the same regardless as the type of comment. As of v0.4.0, the parenthesis and user are styled the same as the type of comment, but can be customized using the [Theme Overrides](#theme-overrides). In particular, the user was styled using the `emphasis.comment.user` theme node. This is no longer the case.
 
 ## Installation
 
@@ -216,6 +219,31 @@ The text after the `:` can also be customized by adding a `.text` after the corr
       "syntax": {
         "property.comment.error.text": {
           "color": "#ff0000"
+          // "background_color": "#00000000",
+          // "font_weight": "bold",
+          // "font_style": "italic"
+        }
+      }
+    }
+  }
+}
+```
+
+Similarly, the parenthesis and user corresponding to an `ERROR:` comment can be styled as follows:
+
+```json
+{
+  "theme_overrides": {
+    "YourThemeName": {
+      "syntax": {
+        "property.comment.error.bracket": {
+          "color": "#000000dd"
+          // "background_color": "#00000000",
+          // "font_weight": "bold",
+          // "font_style": "italic"
+        },
+        "property.comment.error.user": {
+          "color": "#000000dd"
           // "background_color": "#00000000",
           // "font_weight": "bold",
           // "font_style": "italic"

--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/thedadams/zed-comment"
 
 [grammars.comment]
 repository = "https://github.com/thedadams/tree-sitter-comment"
-rev = "7c7c0463ea14b02e3f71fb7ab074b0a08fa182b1"
+rev = "fe3651947a18db814c763244526d214e3c313cdf"

--- a/languages/comment/highlights.scm
+++ b/languages/comment/highlights.scm
@@ -1,35 +1,31 @@
 ((tag
   (name) @_name @constant.comment.todo
-  ("(" @punctuation.bracket
-    (user) @emphasis.comment.user
-    ")" @punctuation.bracket)?
-  ":"? @punctuation.delimiter
+  ("(" @constant.comment.todo.bracket
+    (user) @constant.comment.todo.user
+    ")" @constant.comment.todo.bracket)?
   (text)? @constant.comment.todo.text)
   (#match? @_name "^[</#*;+\\-!| \t]*(TODO|WIP)$"))
 
 ((tag
   (name) @_name @string.comment.info
-  ("(" @punctuation.bracket
-    (user) @emphasis.comment.user
-    ")" @punctuation.bracket)?
-  ":"? @punctuation.delimiter
+  ("(" @string.comment.info.bracket
+    (user) @string.comment.info.user
+    ")" @string.comment.info.bracket)?
   (text)? @string.comment.info.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(NOTE|XXX|INFO|DOCS|PERF|TEST)$"))
 
 ((tag
   (name) @_name @property.comment.error
-  ("(" @punctuation.bracket
-    (user) @emphasis.comment.user
-    ")" @punctuation.bracket)?
-  ":"? @punctuation.delimiter
+  ("(" @property.comment.error.bracket
+    (user) @property.comment.error.user
+    ")" @property.comment.error.bracket)?
   (text)? @property.comment.error.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(FIXME|BUG|ERROR)$"))
 
 ((tag
   (name) @_name @keyword.comment.warn
-  ("(" @punctuation.bracket
-    (user) @emphasis.comment.user
-    ")" @punctuation.bracket)?
-  ":"? @punctuation.delimiter
+  ("(" @keyword.comment.warn.bracket
+    (user) @keyword.comment.warn.user
+    ")" @keyword.comment.warn.bracket)?
   (text)? @keyword.comment.warn.text)
 (#match? @_name "^[</#*;+\\-!| \t]*(HACK|WARNING|WARN|FIX)$"))


### PR DESCRIPTION
Previously, in a comment like `TODO(thedadams): something`, then parenthesis, user, and colon were all style the exact same for all comment types. Additionally, it was not possible to style the parenthesis and colon without changing the look of actual code.

This change will default to theming the parenthesis, user, and colon the same as the rest of the comment. It makes it possible to theme the parenthesis and user differently for each comment type. The colon is now part of the "text" node and is themed accordingly.

Issue: https://github.com/thedadams/zed-comment/issues/27