### PR TITLE
feat: Support SAFETY

### DIFF
--- a/languages/comment/highlights.scm
+++ b/languages/comment/highlights.scm
@@ -28,4 +28,4 @@
     (user) @keyword.comment.warn.user
     ")" @keyword.comment.warn.bracket)?
   (text)? @keyword.comment.warn.text)
-(#match? @_name "^[</#*;+\\-!| \t]*(HACK|WARNING|WARN|FIX)$"))
+(#match? @_name "^[</#*;+\\-!| \t]*(HACK|WARNING|WARN|FIX|SAFETY)$"))


### PR DESCRIPTION
`SAFETY` is commonly used in Rust to provide rationale for `unsafe` blocks.