### PR TITLE
feat: add support for prefix styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An extension for the Zed text editor to highlight according to the corresponding
 - ERROR, FIXME, BUG, DELETE (`property`)
 - WARN, HACK, WARNING, FIX, SAFETY (`keyword`)
 - By default, the user (in the case of something like `NOTE(thedadams):`) and anything after the name and/or user is highlighted the same as the name (`TODO`, `INFO`, `ERROR`, etc). See [Theme Overrides](#theme-overrides) for customization.
+- By default, the prefix (the `//` or the `#` that starts the comment) is styled the same as the type of comment as well, but can also be customized using the [Theme Overrides](#theme-overrides). Similarly for any `*` that starts a line in a multi-line comment.
 
 Ideally, the coloring would be supported by definitions like `comment.info` and `comment.warning`, but those aren't officially supported by Zed themes. However, it is possible to customize these colors using the [Theme Overrides](#theme-overrides) below.
 
@@ -224,13 +225,19 @@ The text after the `:` can also be customized by adding a `.text` after the corr
 }
 ```
 
-Similarly, the parenthesis and user corresponding to an `ERROR:` comment can be styled as follows:
+Similarly, the prefix (the `//`, `#` or `*` that starts a comment line), parenthesis, and user corresponding to an `ERROR:` comment can be styled as follows:
 
 ```jsonc
 {
   "theme_overrides": {
     "YourThemeName": {
       "syntax": {
+        "property.comment.error.prefix": {
+          "color": "#ff0000"
+          // "background_color": "#00000000",
+          // "font_weight": "bold",
+          // "font_style": "italic"
+        },
         "property.comment.error.bracket": {
           "color": "#000000dd"
           // "background_color": "#00000000",

--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/thedadams/zed-comment"
 
 [grammars.comment]
 repository = "https://github.com/thedadams/tree-sitter-comment"
-rev = "93b12e7b219d74fdbbb27e6671ca2f714738b253"
+rev = "5bffb5614e403883f7c2860b8ebae4ebde8b05df"

--- a/languages/comment/highlights.scm
+++ b/languages/comment/highlights.scm
@@ -1,31 +1,47 @@
 ((tag
+  (prefix)? @constant.comment.todo.prefix
   (name) @_name @constant.comment.todo
   ("(" @constant.comment.todo.bracket
     (user) @constant.comment.todo.user
     ")" @constant.comment.todo.bracket)?
-  (text)? @constant.comment.todo.text)
+  (
+    (prefix)? @constant.comment.todo.prefix
+    (text)? @constant.comment.todo.text)
+  )
   (#match? @_name "^[</#*;+\\-!| \t]*(TODO|WIP|MAYBE)$"))
 
 ((tag
+  (prefix)? @string.comment.info.prefix
   (name) @_name @string.comment.info
   ("(" @string.comment.info.bracket
     (user) @string.comment.info.user
     ")" @string.comment.info.bracket)?
-  (text)? @string.comment.info.text)
+  (
+    (prefix)? @string.comment.info.prefix
+    (text)? @string.comment.info.text)
+  )
 (#match? @_name "^[</#*;+\\-!| \t]*(NOTE|XXX|INFO|DOCS|PERF|TEST)$"))
 
 ((tag
+  (prefix)? @property.comment.error.prefix
   (name) @_name @property.comment.error
   ("(" @property.comment.error.bracket
     (user) @property.comment.error.user
     ")" @property.comment.error.bracket)?
-  (text)? @property.comment.error.text)
+  (
+    (prefix)? @property.comment.error.prefix
+    (text)? @property.comment.error.text)
+  )
 (#match? @_name "^[</#*;+\\-!| \t]*(FIXME|BUG|ERROR|DELETE)$"))
 
 ((tag
+  (prefix)? @keyword.comment.warn.prefix
   (name) @_name @keyword.comment.warn
   ("(" @keyword.comment.warn.bracket
     (user) @keyword.comment.warn.user
     ")" @keyword.comment.warn.bracket)?
-  (text)? @keyword.comment.warn.text)
+  (
+    (prefix)? @keyword.comment.warn.prefix
+    (text)? @keyword.comment.warn.text)
+  )
 (#match? @_name "^[</#*;+\\-!| \t]*(HACK|WARNING|WARN|FIX|SAFETY)$"))


### PR DESCRIPTION
This change allows the prefix of the comment `//` or `#` to be styled independently from the rest of the comment.

Issue: https://github.com/thedadams/zed-comment/issues/28