### PR TITLE
fix: ensure all text is highlighted

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/thedadams/zed-comment"
 
 [grammars.comment]
 repository = "https://github.com/thedadams/tree-sitter-comment"
-rev = "23fb30f2eac677f2afaa8556570ca6cd3493aa69"
+rev = "56771424c0026454360ac98b1bf8227a62714622"

--- a/languages/comment/highlights.scm
+++ b/languages/comment/highlights.scm
@@ -1,47 +1,47 @@
 ((tag
   (prefix)? @constant.comment.todo.prefix
-  (name) @_name @constant.comment.todo
+  (name) @constant.comment.todo
   ("(" @constant.comment.todo.bracket
     (user) @constant.comment.todo.user
     ")" @constant.comment.todo.bracket)?
   (
     (prefix)? @constant.comment.todo.prefix
-    (text)? @constant.comment.todo.text)
+    (text)? @constant.comment.todo.text)*
   )
-  (#match? @_name "^(TODO|WIP|MAYBE|QUESTION|\\?)$"))
+  (#match? @constant.comment.todo "^(TODO|WIP|MAYBE|QUESTION|\\?)$"))
 
 ((tag
   (prefix)? @string.comment.info.prefix
-  (name) @_name @string.comment.info
+  (name) @string.comment.info
   ("(" @string.comment.info.bracket
     (user) @string.comment.info.user
     ")" @string.comment.info.bracket)?
   (
     (prefix)? @string.comment.info.prefix
-    (text)? @string.comment.info.text)
+    (text)? @string.comment.info.text)*
   )
-(#match? @_name "^(NOTE|XXX|INFO|DOCS|PERF|TEST|\\*)$"))
+(#match? @string.comment.info "^(NOTE|XXX|INFO|DOCS|PERF|TEST|\\*)$"))
 
 ((tag
   (prefix)? @property.comment.error.prefix
-  (name) @_name @property.comment.error
+  (name) @property.comment.error
   ("(" @property.comment.error.bracket
     (user) @property.comment.error.user
     ")" @property.comment.error.bracket)?
   (
     (prefix)? @property.comment.error.prefix
-    (text)? @property.comment.error.text)
+    (text)? @property.comment.error.text)*
   )
-(#match? @_name "^(FIXME|BUG|ERROR|DELETE|!)$"))
+(#match? @property.comment.error "^(FIXME|BUG|ERROR|DELETE|!)$"))
 
 ((tag
   (prefix)? @keyword.comment.warn.prefix
-  (name) @_name @keyword.comment.warn
+  (name) @keyword.comment.warn
   ("(" @keyword.comment.warn.bracket
     (user) @keyword.comment.warn.user
     ")" @keyword.comment.warn.bracket)?
   (
     (prefix)? @keyword.comment.warn.prefix
-    (text)? @keyword.comment.warn.text)
+    (text)? @keyword.comment.warn.text)*
   )
-(#match? @_name "^(HACK|WARNING|WARN|FIX|SAFETY|#)$"))
+(#match? @keyword.comment.warn "^(HACK|WARNING|WARN|FIX|SAFETY|#)$"))


### PR DESCRIPTION
There was a bug where lines of text would eventutally stop highlighting. This change fixes that by matching one or more siblings of prefix/text pairs.